### PR TITLE
Override az command's output format

### DIFF
--- a/dbgproxy-impl.js
+++ b/dbgproxy-impl.js
@@ -15,7 +15,7 @@ if (Number(process.version.match(/^v(\d+)\./)[1]) < 8) {
 }
 
 function shell(cmdline) {
-  var retval = execSync(cmdline, {stdio: [process.stdin, 'pipe', process.stderr]});
+  var retval = execSync(cmdline + ' -o json', {stdio: [process.stdin, 'pipe', process.stderr]});
   return JSON.parse(retval);
 }
 


### PR DESCRIPTION
If the 'az' command's default output is something other than json (such as jsonc), then the az output cannot be parsed. This change overrides az command's default output setting by always appending '-o json' to command invocations.

Resolves #2 .